### PR TITLE
Update to use personal API tokens

### DIFF
--- a/hubbot
+++ b/hubbot
@@ -83,13 +83,13 @@ def git(*args):
 
 def github_get(url):
     return json.loads(subprocess.check_output ([ "curl", "-s",
-                                                 "-H", "Authorization: token %s" % github_token,
+                                                 "-u", "%s:x-oauth-basic" % github_token,
                                                  "https://api.github.com/repos/%s/%s" % (master_repo, url),
                                              ]))
 
 def add_github_comment(issue, message):
     subprocess.check_call ([ "curl",
-                             "-H", "Authorization: token %s" % github_token,
+                             "-u", "%s:x-oauth-basic" % github_token,
                              "https://api.github.com/repos/%s/issues/%s/comments" % (master_repo, issue),
                              "-d", json.dumps({"body": message})
                            ])


### PR DESCRIPTION
Previously, we were relying on authorization cookies, which did not
allow us to restrict access.